### PR TITLE
Added Wasmer to wasi.dev

### DIFF
--- a/index.md
+++ b/index.md
@@ -25,4 +25,6 @@ cargo +nightly build --target wasm32-wasi
 
 [Lucet](https://github.com/fastly/lucet/) - Fastly's WebAssembly runtime with WASI support.
 
+[Wasmer](https://github.com/wasmerio/wasmer/) - Wasmer WebAssembly runtime with WASI support.
+
 Everything here is a work in progress prototype, and not yet stable.


### PR DESCRIPTION
Now that Wasmer WASI support is mature enough it would be awesome if it's added to the wasi.dev website since it already lists other two runtimes.

Related issue in Wasmer: https://github.com/wasmerio/wasmer/issues/297