### PR TITLE
Consolidate index page

### DIFF
--- a/index.md
+++ b/index.md
@@ -6,23 +6,10 @@ subtitle: The WebAssembly System Interface
 header_text_feature_image: polyfill/WASI-small.png
 ---
 
+WASI is a modular system interface for WebAssembly. As described in [the initial announcement](https://hacks.mozilla.org/2019/03/standardizing-wasi-a-webassembly-system-interface/), it's focused on security and portability.
+
+WASI is being standardized in [a subgroup of the WebAssembly CG](https://github.com/WebAssembly/WASI/blob/master/Charter.md). Discussions happen in [GitHub issues](https://github.com/WebAssembly/WASI/issues), [pull requests](https://github.com/WebAssembly/WASI/pulls), and [bi-weekly Zoom meetings](https://github.com/WebAssembly/WASI/tree/master/meetings).
+
 For a quick intro to WASI, including getting started using it, see [the intro document](https://github.com/CraneStation/wasmtime/blob/master/docs/WASI-intro.md).
 
 For more documentation, see [the documents guide](https://github.com/CraneStation/wasmtime/blob/master/docs/WASI-documents.md).
-
-Here's a quick guide to the repositories where things live:
-
-[wasi-sdk](https://github.com/CraneStation/wasi-sdk) - “WASI SDK” packages for C/C++. If you want to try out compiling C/C++, this is a good place to start. "It's just clang."
-
-WASI-enabled Rust - Rust Nightly builds now have built-in WASI support. To get started using Rust for targeting WASI:
-
-```
-rustup target add wasm32-wasi --toolchain nightly
-cargo +nightly build --target wasm32-wasi
-```
-
-[wasmtime](https://github.com/CraneStation/wasmtime/) - Wasmtime WebAssembly runtime, with WASI support, as well as the WASI documentation.
-
-[Lucet](https://github.com/fastly/lucet/) - Fastly's WebAssembly runtime with WASI support.
-
-Everything here is a work in progress prototype, and not yet stable.


### PR DESCRIPTION
It should link to the announcement, the subgroup, and just couple helpful links to get started, instead of an incomplete and almost always stale list of implementations (for either runtimes or compilers).